### PR TITLE
Add smoke test for #1406

### DIFF
--- a/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaSpies.groovy
+++ b/spock-specs/src/test/groovy/org/spockframework/smoke/mock/JavaSpies.groovy
@@ -223,6 +223,28 @@ class JavaSpies extends Specification {
     thrown(SpockException)
   }
 
+  @Issue("https://github.com/spockframework/spock/issues/1406")
+  def "spy on an interface with a default method"() {
+    given:
+    def interfaceWithDefaultMethod = Spy(InterfaceWithDefaultMethod)
+    def app = new InterfaceUser(interfaceWithDefaultMethod: interfaceWithDefaultMethod)
+
+    when:
+    def result = app.doSomething()
+
+    then:
+    _ * interfaceWithDefaultMethod.normalMethod() >> "bar"
+    result == "bar"
+  }
+
+  static class InterfaceUser {
+    InterfaceWithDefaultMethod interfaceWithDefaultMethod
+
+    String doSomething() {
+      interfaceWithDefaultMethod.defaultMethod()
+    }
+  }
+
   static class Constructable {
     int arg1
     int arg2
@@ -301,4 +323,3 @@ class JavaSpies extends Specification {
     }
   }
 }
-

--- a/spock-specs/src/test/java/org/spockframework/smoke/mock/InterfaceWithDefaultMethod.java
+++ b/spock-specs/src/test/java/org/spockframework/smoke/mock/InterfaceWithDefaultMethod.java
@@ -1,0 +1,9 @@
+package org.spockframework.smoke.mock;
+
+public interface InterfaceWithDefaultMethod {
+  String normalMethod();
+
+  default String defaultMethod() {
+    return normalMethod();
+  }
+}


### PR DESCRIPTION
The smoke test lives in JavaSpies and reproduces the reported issue #1406 on Java 16+ for Spock 2.1-M2. It should however pass with the bugfix in this branch.